### PR TITLE
Single param set/clear + Color

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -63,3 +63,4 @@ common:
 	# osx/iOS only, any framework that should be included in the project
 	ADDON_FRAMEWORKS = CoreMidi
 
+	ADDON_DEFINES = OFX_PARAMETER_TWISTER=1

--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -13,6 +13,17 @@ void ofApp::setup() {
 	mPanel1.setup();
 	mPanel1.add(paramsColor);
 
+	// add event listener for pulse parameter
+	mParamListeners.push_back(mParamPulseEncoders.newListener([this](bool & val) {
+		for (int i = 0; i < 16; ++i) {
+			if (val) {
+				mTwister.setAnimationRotary(i, pal::Kontrol::ofxParameterTwister::Animation::PULSE, i % 4);
+			} else {
+				mTwister.setAnimationRotary(i, pal::Kontrol::ofxParameterTwister::Animation::NONE);
+			}
+		}
+	}));
+
 
 	mCam1.setupPerspective(false, 60, 0.1, 5000);
 	mCam1.setPosition(ofVec3f(0, 0, 300));
@@ -34,6 +45,16 @@ void ofApp::update() {
 	// Place the above call before or after your other update code, 
 	// depending at which point during execution you want midi parameters to 
 	// affect your design
+
+	if (mParamDemoMode) {
+		float time = ofGetElapsedTimef();
+		for (int j = 0; j < 4; ++j) {
+			for (int i = 0; i < 4; ++i) {
+				float val = fmod(time * .5f + (i + j) / 9.f, 1.f);
+				mTwister.setHueRGB(j * 4 + i, val);
+			}
+		}
+	}
 
 }
 
@@ -103,15 +124,23 @@ void ofApp::keyPressed(int key) {
 		mPanel1.clear();
 		mPanel1.add(paramsColor);
 		mTwister.setParams(paramsColor);
+		mParamDemoMode = false;
 		break;
 	case 'b':
 		mPanel1.clear();
 		mPanel1.add(paramsShape);
 		mTwister.setParams(paramsShape);
+		mParamDemoMode = false;
+		break;
+	case 'c':
+		mPanel1.clear();
+		mTwister.clear();
+		mParamDemoMode = true;
 		break;
 	case 'i':
 		mParamShouldDrawInfo ^= true;
 		break;
+
 	default:
 		break;
 	}

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -14,8 +14,8 @@ class ofApp : public ofBaseApp{
 	ofParameter<float> 	mParamS{ "S", 0.f, 0.f, 255.f };
 	ofParameter<float> 	mParamB{ "B", 255.f, 0.f, 255.f };
 	ofParameter<float> 	mParamA{ "A", 255.f, 0.f, 255.f };
-	ofParameter<bool> 	mParamUseAlpha{ "UseAlpha", true };
-	ofParameter<bool> 	mParamShouldDrawInfo{ "Toggle Info Text", true };
+	ofParameter<bool> 	mParamUseAlpha{ "Use Alpha", true };
+	ofParameter<bool> 	mParamPulseEncoders{ "Pulse Encoders", false };
 
 	ofParameterGroup paramsColor{
 		"Color",
@@ -24,11 +24,13 @@ class ofApp : public ofBaseApp{
 		mParamB,
 		mParamA,
 		mParamUseAlpha,
+		mParamPulseEncoders
 	};
 
 	ofParameter<float> 	mParamSize{ "Size", 75.f, 30.f, 400.f };
 	ofParameter<float> 	mParamResolution{ "Resolution", 1.f, 0.5f, 4.f };
 	ofParameter<bool> 	mParamIsWireframe{ "WireFrame", true };
+	ofParameter<bool> 	mParamShouldDrawInfo{ "Toggle Info Text", true };
 
 	ofParameterGroup paramsShape{
 		"Shape",
@@ -37,6 +39,10 @@ class ofApp : public ofBaseApp{
 		mParamIsWireframe,
 		mParamShouldDrawInfo,
 	};
+
+	ofParameter<bool> 	mParamDemoMode{ "Demo Mode", false };
+
+	std::vector<ofEventListener> mParamListeners;
 
 	ofxPanel mPanel1;
 

--- a/src/ofxParameterTwister.cpp
+++ b/src/ofxParameterTwister.cpp
@@ -122,8 +122,7 @@ void ofxParameterTwister::setup() {
 
 void ofxParameterTwister::clear() {
 	for (auto & e : mEncoders) {
-		e.setState(Encoder::State::DISABLED, true);
-		e.mELParamChange = ofEventListener(); // reset listener
+		clearParam(e, true);
 	}
 }
 
@@ -157,8 +156,7 @@ void ofxParameterTwister::setParams(const ofParameterGroup& group_) {
 
 			} else {
 				// we cannot match this parameter, unfortunately
-				e.setState(Encoder::State::DISABLED);
-				e.mELParamChange = ofEventListener(); // reset listener
+				clearParam(e, false);
 			}
 			
 			it++;
@@ -227,16 +225,16 @@ void ofxParameterTwister::setParam(Encoder& encoder_, ofParameter<bool>& param_)
 
 // ------------------------------------------------------
 
-void ofxParameterTwister::clearParam(size_t idx_) {
+void ofxParameterTwister::clearParam(size_t idx_, bool force_) {
 	if (idx_ < mEncoders.size()) {
-		clearParam(mEncoders[idx_]);
+		clearParam(mEncoders[idx_], force_);
 	}
 }
 
 // ------------------------------------------------------
 
-void ofxParameterTwister::clearParam(Encoder& encoder_) {
-	encoder_.setState(Encoder::State::DISABLED);
+void ofxParameterTwister::clearParam(Encoder& encoder_, bool force_) {
+	encoder_.setState(Encoder::State::DISABLED, force_);
 	encoder_.mELParamChange = ofEventListener(); // reset listener
 }
 

--- a/src/ofxParameterTwister.cpp
+++ b/src/ofxParameterTwister.cpp
@@ -289,13 +289,16 @@ void ofxParameterTwister::setAnimationRGB(Encoder& encoder_, Animation anim_, ui
 	uint8_t mode;
 	switch (anim_)
 	{
-	case Animation::Strobe:
+	case Animation::NONE:
+		mode = 0;
+		break;
+	case Animation::STROBE:
 		mode = 1 + rate_;
 		break;
-	case Animation::Pulse:
+	case Animation::PULSE:
 		mode = 9 + rate_;
 		break;
-	case Animation::Rainbow:
+	case Animation::RAINBOW:
 	default:
 		mode = 127;
 	}
@@ -323,7 +326,7 @@ void ofxParameterTwister::setBrightnessRotary(Encoder& encoder_, float bri_)
 
 void ofxParameterTwister::setAnimationRotary(size_t idx_, Animation anim_, uint8_t rate_)
 {
-	if (idx_ < mEncoders.size() && rate_ < 8 && anim_ != Animation::Rainbow)
+	if (idx_ < mEncoders.size() && rate_ < 8 && anim_ != Animation::RAINBOW)
 	{
 		setAnimationRotary(mEncoders[idx_], anim_, rate_);
 	}
@@ -336,10 +339,13 @@ void ofxParameterTwister::setAnimationRotary(Encoder& encoder_, Animation anim_,
 	uint8_t mode;
 	switch (anim_)
 	{
-	case Animation::Strobe:
+	case Animation::NONE:
+		mode = 48;
+		break; 
+	case Animation::STROBE:
 		mode = 49 + rate_;
 		break;
-	case Animation::Pulse:
+	case Animation::PULSE:
 	default:
 		mode = 57 + rate_;
 		break;

--- a/src/ofxParameterTwister.cpp
+++ b/src/ofxParameterTwister.cpp
@@ -227,6 +227,21 @@ void ofxParameterTwister::setParam(Encoder& encoder_, ofParameter<bool>& param_)
 
 // ------------------------------------------------------
 
+void ofxParameterTwister::clearParam(size_t idx_) {
+	if (idx_ < mEncoders.size()) {
+		clearParam(mEncoders[idx_]);
+	}
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::clearParam(Encoder& encoder_) {
+	encoder_.setState(Encoder::State::DISABLED);
+	encoder_.mELParamChange = ofEventListener(); // reset listener
+}
+
+// ------------------------------------------------------
+
 void ofxParameterTwister::update() {
 
 	MidiCCMessage m;

--- a/src/ofxParameterTwister.cpp
+++ b/src/ofxParameterTwister.cpp
@@ -240,6 +240,115 @@ void ofxParameterTwister::clearParam(Encoder& encoder_, bool force_) {
 
 // ------------------------------------------------------
 
+void ofxParameterTwister::setHueRGB(size_t idx_, float hue_)
+{
+	if (idx_ < mEncoders.size()) 
+	{
+		setHueRGB(mEncoders[idx_], hue_);
+	}
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setHueRGB(Encoder& encoder_, float hue_)
+{
+	encoder_.setHueRGB(hue_);
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setBrightnessRGB(size_t idx_, float bri_)
+{
+	if (idx_ < mEncoders.size())
+	{
+		setBrightnessRGB(mEncoders[idx_], bri_);
+	}
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setBrightnessRGB(Encoder& encoder_, float bri_)
+{
+	encoder_.setBrightnessRGB(bri_);
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setAnimationRGB(size_t idx_, Animation anim_, uint8_t rate_)
+{
+	if (idx_ < mEncoders.size() && rate_ < 8)
+	{
+		setAnimationRGB(mEncoders[idx_], anim_, rate_);
+	}
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setAnimationRGB(Encoder& encoder_, Animation anim_, uint8_t rate_)
+{
+	uint8_t mode;
+	switch (anim_)
+	{
+	case Animation::Strobe:
+		mode = 1 + rate_;
+		break;
+	case Animation::Pulse:
+		mode = 9 + rate_;
+		break;
+	case Animation::Rainbow:
+	default:
+		mode = 127;
+	}
+	encoder_.setAnimation(mode);
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setBrightnessRotary(size_t idx_, float bri_)
+{
+	if (idx_ < mEncoders.size())
+	{
+		setBrightnessRotary(mEncoders[idx_], bri_);
+	}
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setBrightnessRotary(Encoder& encoder_, float bri_)
+{
+	encoder_.setBrightnessRotary(bri_);
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setAnimationRotary(size_t idx_, Animation anim_, uint8_t rate_)
+{
+	if (idx_ < mEncoders.size() && rate_ < 8 && anim_ != Animation::Rainbow)
+	{
+		setAnimationRotary(mEncoders[idx_], anim_, rate_);
+	}
+}
+
+// ------------------------------------------------------
+
+void ofxParameterTwister::setAnimationRotary(Encoder& encoder_, Animation anim_, uint8_t rate_)
+{
+	uint8_t mode;
+	switch (anim_)
+	{
+	case Animation::Strobe:
+		mode = 49 + rate_;
+		break;
+	case Animation::Pulse:
+	default:
+		mode = 57 + rate_;
+		break;
+	}
+	encoder_.setAnimation(mode);
+}
+
+// ------------------------------------------------------
+
 void ofxParameterTwister::update() {
 
 	MidiCCMessage m;
@@ -286,7 +395,6 @@ void pal::Kontrol::ofxParameterTwister::Encoder::setState(State s_, bool force_)
 	switch (s_)
 	{
 	case pal::Kontrol::ofxParameterTwister::Encoder::State::DISABLED:
-		setEncoderAnimation(0);
 		// we need to switch off the status LED
 		sendToSwitch(0);
 		// we need to switch off the rotary status LED
@@ -303,7 +411,6 @@ void pal::Kontrol::ofxParameterTwister::Encoder::setState(State s_, bool force_)
 		sendToRotary(0);
 		setBrightnessRotary(0.f);
 		setBrightnessRGB(1.0f);
-		setEncoderAnimation(65);
 		break;
 	default:
 		break;
@@ -372,17 +479,17 @@ void pal::Kontrol::ofxParameterTwister::Encoder::sendToRotary(uint8_t v_) {
 
 // ------------------------------------------------------
 
-void pal::Kontrol::ofxParameterTwister::Encoder::setBrightnessRotary(float b_)
+void pal::Kontrol::ofxParameterTwister::Encoder::setHueRGB(float h_)
 {
 	if (mMidiOut == nullptr)
 		return;
 
 	// ----------| invariant: midiOut is not nullptr
 
-	unsigned char val = std::roundf(ofMap(b_, 0.f, 1.f, 65, 95, true));
-	
+	unsigned char val = std::roundf(ofMap(h_, 0.f, 1.f, 1, 126, true));
+
 	vector<unsigned char> msg{
-		0xB2,					// animation control channel 2
+		0xB1,					// color control channel 1 
 		pos,					// device id
 		val,
 	};
@@ -411,11 +518,31 @@ void pal::Kontrol::ofxParameterTwister::Encoder::setBrightnessRGB(float b_)
 	mMidiOut->sendMessage(&msg);
 
 }
-// ------------------------------------------------------
 
 // ------------------------------------------------------
 
-void pal::Kontrol::ofxParameterTwister::Encoder::setEncoderAnimation(uint8_t v_)
+void pal::Kontrol::ofxParameterTwister::Encoder::setBrightnessRotary(float b_)
+{
+	if (mMidiOut == nullptr)
+		return;
+
+	// ----------| invariant: midiOut is not nullptr
+
+	unsigned char val = std::roundf(ofMap(b_, 0.f, 1.f, 65, 95, true));
+	
+	vector<unsigned char> msg{
+		0xB2,					// animation control channel 2
+		pos,					// device id
+		val,
+	};
+
+	mMidiOut->sendMessage(&msg);
+
+}
+
+// ------------------------------------------------------
+
+void pal::Kontrol::ofxParameterTwister::Encoder::setAnimation(uint8_t v_)
 {
 	if (mMidiOut == nullptr)
 		return;

--- a/src/ofxParameterTwister.cpp
+++ b/src/ofxParameterTwister.cpp
@@ -120,6 +120,12 @@ void ofxParameterTwister::setup() {
 
 // ------------------------------------------------------
 
+void ofxParameterTwister::clear() {
+	for (auto & e : mEncoders) {
+		e.setState(Encoder::State::DISABLED, true);
+		e.mELParamChange = ofEventListener(); // reset listener
+	}
+}
 
 // ------------------------------------------------------
 

--- a/src/ofxParameterTwister.h
+++ b/src/ofxParameterTwister.h
@@ -110,10 +110,14 @@ public:
 	void setParam(size_t idx_, ofParameter<float>& param_);
 	void setParam(size_t idx_, ofParameter<bool>& param_);
 
+	void clearParam(size_t idx_);
+
 private:
 
 	void setParam(Encoder& encoder_, ofParameter<float>& param_);
 	void setParam(Encoder& encoder_, ofParameter<bool>& param_);
+
+	void clearParam(Encoder& encoder_);
 
 	RtMidiIn*	mMidiIn = nullptr;
 	RtMidiOut*	mMidiOut = nullptr;

--- a/src/ofxParameterTwister.h
+++ b/src/ofxParameterTwister.h
@@ -102,6 +102,7 @@ public:
 	~ofxParameterTwister();
 
 	void setup();
+	void clear();
 
 	void update(); // this is where we apply values.
 	void setParams(const ofParameterGroup& group_);

--- a/src/ofxParameterTwister.h
+++ b/src/ofxParameterTwister.h
@@ -110,14 +110,14 @@ public:
 	void setParam(size_t idx_, ofParameter<float>& param_);
 	void setParam(size_t idx_, ofParameter<bool>& param_);
 
-	void clearParam(size_t idx_);
+	void clearParam(size_t idx_, bool force_ = false);
 
 private:
 
 	void setParam(Encoder& encoder_, ofParameter<float>& param_);
 	void setParam(Encoder& encoder_, ofParameter<bool>& param_);
 
-	void clearParam(Encoder& encoder_);
+	void clearParam(Encoder& encoder_, bool force_);
 
 	RtMidiIn*	mMidiIn = nullptr;
 	RtMidiOut*	mMidiOut = nullptr;

--- a/src/ofxParameterTwister.h
+++ b/src/ofxParameterTwister.h
@@ -105,9 +105,15 @@ public:
 	void clear();
 
 	void update(); // this is where we apply values.
+
 	void setParams(const ofParameterGroup& group_);
+	void setParam(size_t idx_, ofParameter<float>& param_);
+	void setParam(size_t idx_, ofParameter<bool>& param_);
 
 private:
+
+	void setParam(Encoder& encoder_, ofParameter<float>& param_);
+	void setParam(Encoder& encoder_, ofParameter<bool>& param_);
 
 	RtMidiIn*	mMidiIn = nullptr;
 	RtMidiOut*	mMidiOut = nullptr;

--- a/src/ofxParameterTwister.h
+++ b/src/ofxParameterTwister.h
@@ -102,9 +102,10 @@ public:
 	
 	enum class Animation
 	{
-		Strobe,
-		Pulse,
-		Rainbow
+		NONE,
+		STROBE,
+		PULSE,
+		RAINBOW
 	};
 
 	~ofxParameterTwister();

--- a/src/ofxParameterTwister.h
+++ b/src/ofxParameterTwister.h
@@ -90,15 +90,23 @@ class ofxParameterTwister
 		void sendToSwitch(uint8_t v_);
 		void sendToRotary(uint8_t v_);
 
-		void setEncoderAnimation(uint8_t v_);
-		void setBrightnessRotary(float b_); /// brightness is normalised over 31 steps 0..30
+		void setHueRGB(float h_);
 		void setBrightnessRGB(float b_);
+		void setBrightnessRotary(float b_); /// brightness is normalised over 31 steps 0..30
+
+		void setAnimation(uint8_t v_);
 	};
 
 
 public:
 	
-	
+	enum class Animation
+	{
+		Strobe,
+		Pulse,
+		Rainbow
+	};
+
 	~ofxParameterTwister();
 
 	void setup();
@@ -112,12 +120,26 @@ public:
 
 	void clearParam(size_t idx_, bool force_ = false);
 
+	void setHueRGB(size_t idx_, float hue_);
+	void setBrightnessRGB(size_t idx_, float bri_);
+	void setAnimationRGB(size_t idx_, Animation anim_, uint8_t rate_ = 0);
+	
+	void setBrightnessRotary(size_t idx_, float bri_);
+	void setAnimationRotary(size_t idx_, Animation anim_, uint8_t rate_ = 0);
+
 private:
 
 	void setParam(Encoder& encoder_, ofParameter<float>& param_);
 	void setParam(Encoder& encoder_, ofParameter<bool>& param_);
 
 	void clearParam(Encoder& encoder_, bool force_);
+
+	void setHueRGB(Encoder& encoder_, float hue_);
+	void setBrightnessRGB(Encoder& encoder_, float bri_);
+	void setAnimationRGB(Encoder& encoder_, Animation anim_, uint8_t rate_);
+
+	void setBrightnessRotary(Encoder& encoder_, float bri_);
+	void setAnimationRotary(Encoder& encoder_, Animation anim_, uint8_t rate_);
 
 	RtMidiIn*	mMidiIn = nullptr;
 	RtMidiOut*	mMidiOut = nullptr;


### PR DESCRIPTION
Hello,
I played around with this a bit today and finished the updates I had started for the Entropy show. 
Notably:
- Added methods to set and clear a single encoder at a time (instead of having to use a group).
- Added public methods to trigger animation modes.
- Added methods to set the hue of the RGB led.
- Added a new option to the example. Hit the `c` key to see the encoder go into demo mode :)