### PR TITLE
Fix MIDI on Windows

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -63,6 +63,9 @@ common:
 	# osx/iOS only, any framework that should be included in the project
 	ADDON_FRAMEWORKS = CoreMidi
 
+vs:
+	ADDON_DEFINES += __WINDOWS_MM__
+
 linux:
-    ADDON_DEFINES += __LINUX_ALSA__
+	ADDON_DEFINES += __LINUX_ALSA__
 


### PR DESCRIPTION
Hey Tim!

I just tried using this old addon again and couldn't get RtMidi to work out of the box on Windows. I ended up having to explicitly set the `__WINDOWS_MM__` define in the config to get it to work.

However, that define is already set in ofConstants.h, but I can't figure out where to include it for it to get "picked up" on time. The only place where it's actually working is at the top of the `RtMidi.cpp` file, but that feels like bad practice.

Let me know if you have a suggestion for a better way to resolve this... 